### PR TITLE
Method added & and minor improvement

### DIFF
--- a/examples/usage.ino
+++ b/examples/usage.ino
@@ -3,6 +3,12 @@
 EasyPCF8574 pcf_A(0x27,0); //PCF address, initial value
 EasyPCF8574 pcf_B(0x29,0);
 
+/* This below function is for demonstration of "WriteBit" method 
+it is useless in your final code */
+bool MyBoolFunction(){
+    return true;
+}
+
 void setup() {
     Serial.begin(9600);
     //ESP32 example. You can use overloaded function with no parameters in startI2C() method.
@@ -13,43 +19,50 @@ void setup() {
 }
 
 void loop() {
-    Serial.println(" Starting cycle:");
+    Serial.println("==========> New cycle:");
     Serial.println("Initial value (as specified):");
-    Serial.println(pcf_A.getPCFValue());
+    Serial.println(pcf_A.getPCFValue(), BIN);
     delay(500);
     
     Serial.println("Setting value to (39):");
     //00100111
     pcf_A.setFullValue(0x27); //like pcf address :)
     Serial.println("Byte now is:");
-    Serial.println(pcf_A.getPCFValue());
+    Serial.println(pcf_A.getPCFValue(), BIN);
     delay(500);
 
     Serial.println("Checking bit 2 status:"); //bits starts in 0, from right to left
-    Serial.println(pcf_A.getBitValue(2));
+    Serial.println(pcf_A.getBitValue(2), BIN);
     Serial.println("Byte now is:");
-    Serial.println(pcf_A.getPCFValue());
+    Serial.println(pcf_A.getPCFValue(), BIN);
     delay(500);
 
-    Serial.println("Inverting  bit 2 value");
-    pcf_A.setInvertBit(2);
-    Serial.println(pcf_A.getBitValue(2));
+    Serial.println("Inverting  bit 7 value");
+    pcf_A.setInvertBit(7);
+    Serial.println(pcf_A.getBitValue(7), BIN);
     Serial.println("Byte now is:");
-    Serial.println(pcf_A.getPCFValue());
+    Serial.println(pcf_A.getPCFValue(), BIN);
     delay(500);
 
     Serial.println("Set bit 2 up:");
     pcf_A.setUpBit(2);
-    Serial.println(pcf_A.getBitValue(2));
+    Serial.println(pcf_A.getBitValue(2), BIN);
     Serial.println("Byte now is:");
-    Serial.println(pcf_A.getPCFValue());
+    Serial.println(pcf_A.getPCFValue(), BIN);
     delay(500);
 
     Serial.println("Set bit 2 down");
     pcf_A.setDownBit(2);
-    Serial.println(pcf_A.getBitValue(2));
+    Serial.println(pcf_A.getBitValue(2), BIN);
     Serial.println("Byte now is:");
-    Serial.println(pcf_A.getPCFValue());
+    Serial.println(pcf_A.getPCFValue(), BIN);
+    delay(500);
+
+    Serial.println("Copy a bit from parameter");
+    pcf_A.WriteBit(MyBoolFunction(),2);
+    Serial.println(pcf_A.getBitValue(2), BIN);
+    Serial.println("Byte now is:");
+    Serial.println(pcf_A.getPCFValue(), BIN);
     delay(500);
 
     Serial.println("Done.");

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/DjamesSuhanko",
         "maintainer": true
     },
-    "version": "1.0.4",
+    "version": "1.0.5",
     "license": "MIT",
     "frameworks": "arduino",
     "platforms": "*"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EasyPCF8574
-version=1.0.4
+version=1.0.5
 author=Djames Suhanko
 maintainer=Djames Suhanko
 sentence=Generic library for PCF8574 easy to use

--- a/src/EasyPCF8574.cpp
+++ b/src/EasyPCF8574.cpp
@@ -54,7 +54,17 @@ void EasyPCF8574::setUpBit(uint8_t bit_to_change){
 }
 
 void EasyPCF8574::setUpBit(uint8_t bit_to_change, uint8_t pcf_addr){
-        this->pcf_last_value = pcf_last_value|(1<<bit_to_change);
+    this->pcf_last_value = pcf_last_value|(1<<bit_to_change);
+    this->setFullValue(this->pcf_last_value, pcf_addr);
+}
+
+void EasyPCF8574::WriteBit(bool value_to_write, uint8_t bit_to_change){
+    this->pcf_last_value = pcf_last_value ^(-value_to_write ^ pcf_last_value) & (1<<bit_to_change);
+    this->setFullValue(this->pcf_last_value);
+}
+
+void EasyPCF8574::WriteBit(bool value_to_write, uint8_t bit_to_change, uint8_t pcf_addr){
+    this->pcf_last_value = pcf_last_value ^(-value_to_write ^ pcf_last_value) & (1<<bit_to_change);
     this->setFullValue(this->pcf_last_value, pcf_addr);
 }
 
@@ -97,6 +107,7 @@ uint8_t EasyPCF8574::getBitValue(uint8_t bit_position, uint8_t pcf_addr){
 bool EasyPCF8574::startI2C(uint8_t sda_pin, uint8_t scl_pin){
     if (Wire.begin(sda_pin,scl_pin)){
         this->started = true;
+        this->setFullValue(this->pcf_last_value);
         return true;
     }
 }
@@ -104,6 +115,7 @@ bool EasyPCF8574::startI2C(uint8_t sda_pin, uint8_t scl_pin){
 bool EasyPCF8574::startI2C(){
     if (Wire.begin()){
         this->started = true;
+        this->setFullValue(this->pcf_last_value);
         return true;
     }
 }

--- a/src/EasyPCF8574.h
+++ b/src/EasyPCF8574.h
@@ -37,6 +37,11 @@ class EasyPCF8574{
     //! Overriding method, passing pcf_address if more than one is connected
     void setUpBit(uint8_t bit_to_change, uint8_t pcf_addr);
 
+    //! Direct write bit, no matter of actual state
+    void WriteBit(bool value_to_write, uint8_t bit_to_change);
+    //! Overriding method, passing pcf_address if more than one is connected
+    void WriteBit(bool value_to_write, uint8_t bit_to_change, uint8_t pcf_addr);
+
     //! Gets PCF8574 actual value.
     uint8_t getPCFValue();
     //! Overloaded (or 'Overriding'?) method, passing pcf_address if more than one is connected


### PR DESCRIPTION
WriteBit method added to allow to write a bit from a parameter source (e.g. from another function).

startI2C will now push the initial value to PCF8574, 
otherwise the initial value is useless until the first set/reset/invert.

The example received the new method.
Because the loop will repeat forever I added a "====>" to the cycle begin in order to make this more visual in serial output
The serial output display values in BIN format witch is more readable